### PR TITLE
Added function to recursively get parent custom focus scope

### DIFF
--- a/lib/src/utils/focus_helper.dart
+++ b/lib/src/utils/focus_helper.dart
@@ -126,4 +126,16 @@ abstract class FocusHelper {
 
     return true;
   }
+
+  ///Get parent CustomFocusScopeNode with `recursions`.
+  ///
+  /// 1 - gets parent of a parent
+  static CustomFocusScopeNode? getParentCustomFocusScopeNode({int recursions = 0}) {
+    if (recursions <= 0) {
+      return FocusManager.instance.primaryFocus?.parentCustomFocusScopeNode;
+    }
+    return getParentCustomFocusScopeNode(
+      recursions: recursions - 1,
+    )?.parentCustomFocusScopeNode;
+  }
 }


### PR DESCRIPTION
До: нет удобного способа найти CustomFocusScopeNode выше чем у родителя
После: добавил рекурсивный способ

Ссылка:
https://appraiders.atlassian.net/jira/software/c/projects/MLABTV/boards/8?selectedIssue=MLABTV-685